### PR TITLE
added support for fixed colour scheme. MAF and SO terms are supported…

### DIFF
--- a/R/oncoplot.R
+++ b/R/oncoplot.R
@@ -37,7 +37,7 @@
 #'   col_mutation_type = "Variant_Classification"
 #' )
 #'
-ggoncoplot <- function(.data, col_genes, col_samples, col_mutation_type = NULL, genes_to_include = NULL, col_tooltip = col_samples, topn = 10, show_sample_ids = FALSE, interactive = TRUE, interactive_svg_width = 12, interactive_svg_height = 6, xlab_title = "Sample", ylab_title = "Gene") {
+ggoncoplot <- function(.data, col_genes, col_samples, col_mutation_type = NULL, genes_to_include = NULL, col_tooltip = col_samples, topn = 10, palette = NULL, show_sample_ids = FALSE, interactive = TRUE, interactive_svg_width = 12, interactive_svg_height = 6, xlab_title = "Sample", ylab_title = "Gene") {
   assertthat::assert_that(is.data.frame(.data))
   assertthat::assert_that(assertthat::is.string(col_genes))
   assertthat::assert_that(assertthat::is.string(col_samples))
@@ -60,6 +60,7 @@ ggoncoplot <- function(.data, col_genes, col_samples, col_mutation_type = NULL, 
   gg <-  ggoncoplot_plot(
     .data = data_top_df,
     show_sample_ids = show_sample_ids, interactive = interactive, interactive_svg_width = interactive_svg_width,
+    palette = palette,
     interactive_svg_height = interactive_svg_height,
     xlab_title = xlab_title,
     ylab_title = ylab_title
@@ -227,15 +228,55 @@ ggoncoplot_prep_df <- function(.data, col_genes, col_samples, col_mutation_type 
 #' Plot oncoplot
 #'
 #' This function takes the output from \strong{ggoncoplot_prep_df} and plots it.
-#' Should not be exposed since it makes some assumptions
+#' Should not be exposed since it makes some assumptions about structure of input data.
 #'
 #' @inheritParams ggoncoplot
 #' @param .data transformed data from [ggoncoplot_prep_df()] (data.frame)
 #' @inherit ggoncoplot return
 #' @inherit ggoncoplot examples
-ggoncoplot_plot <- function(.data, show_sample_ids = FALSE, interactive = TRUE, interactive_svg_width = 12, interactive_svg_height = 6, xlab_title = "Sample", ylab_title = "Gene"){
+ggoncoplot_plot <- function(.data, show_sample_ids = FALSE, interactive = TRUE, palette = NULL, interactive_svg_width = 12, interactive_svg_height = 6, xlab_title = "Sample", ylab_title = "Gene"){
 
-  check_valid_dataframe_column(.data, c('Gene', 'Sample', 'MutationType'))
+  check_valid_dataframe_column(.data, c('Gene', 'Sample', 'MutationType', 'Tooltip'))
+
+  # Consistent Colour Scheme
+  unique_impacts <- unique(.data[['MutationType']])
+  unique_impacts_minus_multiple <- unique_impacts[unique_impacts != "Multiple"]
+
+
+  if(all(is.na(unique_impacts))){
+    palette <- NA
+  }
+  else if(is.null(palette)){
+    mutation_dictionary <- mutationtypes::mutation_types_identify(unique_impacts_minus_multiple)
+
+    if(mutation_dictionary == "MAF"){
+      cli::cli_alert_success('Mutation Types are described using valid MAF terms ... using MAF palete')
+      palette <- c(mutationtypes::mutation_types_maf_palette(), Multiple = "black")
+      palette <- palette[names(palette) %in% unique_impacts]
+    }
+    else if(mutation_dictionary == "SO"){
+      cli::cli_alert_success('Mutation Types are described using valid SO terminology ... using SO palete')
+      palette <- c(mutationtypes::mutation_types_so_palette(), Multiple = "black")
+      palette <- palette[names(palette) %in% unique_impacts]
+    }
+    else{
+      cli::cli_alert_warning('Mutation Types are not described with any known ontology.
+                             Using an RColorBrewer palette by default.
+                             When running this plot with other datasets, it is possible the colour scheme may differ.
+                             We STRONGLY reccomend supplying a custom MutationType -> colour mapping using the {.arg palette} argument')
+
+      #.data[['MutationType']] <- forcats::fct_infreq(f = .data[['MutationType']])
+      rlang::check_installed("RColorBrewer", reason = "To create default palette for `ggoncoplot()`")
+      palette <- RColorBrewer::brewer.pal(n=12, name = "Paired")
+    }
+  }
+  else{
+   if(!all(unique_impacts %in% names(palette))) {
+     terms_without_mapping <- unique_impacts[!unique_impacts %in% names(palette)]
+    cli::cli_abort('Please add colour mappings for the following terms: {terms_without_mapping}')
+   }
+  }
+
 
   # Create ggplot
   gg <- ggplot2::ggplot(
@@ -261,7 +302,7 @@ ggoncoplot_plot <- function(.data, show_sample_ids = FALSE, interactive = TRUE, 
   gg <- gg + ggplot2::xlab(xlab_title) + ggplot2::ylab(ylab_title)
 
   # Add fill colour
-  gg <- gg + ggplot2::scale_fill_manual(values = RColorBrewer::brewer.pal(n = 12, "Paired"))
+  gg <- gg + ggplot2::scale_fill_manual(values = palette)
 
   # Show/hide sample ids on x axis
   if (!show_sample_ids) {
@@ -390,3 +431,22 @@ check_valid_dataframe_column <- function(data, colnames, error_call = rlang::cal
   }
   invisible(TRUE)
 }
+
+
+
+#' Title
+#'
+#' @param mutation_types the different mutation types (character)
+#'
+#' @return
+#'
+get_colours_of_mutations <- function(mutation_types){
+  assertthat::assert_that(is.character(mutation_types))
+
+  mutation_types_unique <- unique(mutation_types)
+
+
+
+}
+
+

--- a/tests/testthat/test-oncoplot.R
+++ b/tests/testthat/test-oncoplot.R
@@ -14,7 +14,7 @@ test_that("ggoncoplot runs without error", {
       col_samples = "Tumor_Sample_Barcode",
       col_mutation_type = "Variant_Classification",
       interactive = FALSE
-    ),
+    ) |> suppressMessages(),
     regexp = NA
   )
 
@@ -26,7 +26,7 @@ test_that("ggoncoplot runs without error", {
       col_samples = "Tumor_Sample_Barcode",
       col_mutation_type = "Variant_Classification",
       interactive = TRUE
-    ),
+    ) |> suppressMessages(),
     regexp = NA
   )
 
@@ -38,7 +38,7 @@ test_that("ggoncoplot runs without error", {
       col_samples = "Tumor_Sample_Barcode",
       col_mutation_type = "Variant_Classification",
       interactive = TRUE
-    ),
+    ) |> suppressMessages(),
     class = "girafe"
   )
 
@@ -51,7 +51,7 @@ test_that("ggoncoplot runs without error", {
       col_samples = "Tumor_Sample_Barcode",
       col_mutation_type = "Variant_Classification",
       interactive = TRUE
-    ),
+    ) |> suppressMessages(),
     class = "girafe"
   )
 
@@ -64,7 +64,7 @@ test_that("ggoncoplot runs without error", {
       col_samples = "Tumor_Sample_Barcode",
       col_mutation_type = "Variant_Classification",
       interactive = FALSE
-    ),
+    ) |> suppressMessages(),
     class = "ggplot"
   )
 
@@ -77,7 +77,7 @@ test_that("ggoncoplot runs without error", {
         col_samples = 'Tumor_Sample_Barcode',
         col_mutation_type = 'Variant_Classification',
         col_tooltip = 'tooltip' # We'll specify a custom tooltip based on our new 'tooltip' column
-      ),
+      ) |> suppressMessages(),
     NA
   )
 


### PR DESCRIPTION
… by default. If not using either of these dictionaries, will default to the paired rcolourbrewer pal based on alphabetic order and warn user to specify custom mapping